### PR TITLE
Signal to hapi that plugin registration is done.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -40,6 +40,8 @@ FalcorEndpoint.dataSourceRoute = function(getDataSource) {
 
 FalcorEndpoint.register = function (server, options, next) {
     server.handler("falcor", internals.falcorHandler);
+    
+    next();
 };
 
 FalcorEndpoint.register.attributes = {


### PR DESCRIPTION
Otherwise, this prevents hapi from bootstrapping.